### PR TITLE
Add example PDF overlay scripts

### DIFF
--- a/pdf_layout/README.md
+++ b/pdf_layout/README.md
@@ -1,0 +1,13 @@
+# PDF Layout Example
+
+This folder contains a minimal demonstration of how to create dynamic PDF layouts using **PyPDF2** from a PHP script. The `generate_pdf.php` script builds a data set, writes it to a temporary JSON file and calls `generate_pdf.py` via `python3`.
+
+`generate_pdf.py` uses PyPDF2 together with ReportLab to overlay text on a template PDF. Positions are specified in millimetres and can be configured via the JSON payload. The Python script also demonstrates how repeating sections (e.g. transactions) can be drawn dynamically.
+
+## Usage
+
+```
+php generate_pdf.php <template.pdf> <output.pdf>
+```
+
+Ensure `python3`, `PyPDF2` and `reportlab` are installed in your environment.

--- a/pdf_layout/generate_pdf.php
+++ b/pdf_layout/generate_pdf.php
@@ -1,0 +1,28 @@
+<?php
+if ($argc < 3) {
+    echo "Usage: php generate_pdf.php <template> <output>\n";
+    exit(1);
+}
+$template = $argv[1];
+$output = $argv[2];
+$data = [
+    'fields' => [
+        [
+            'page' => 0,
+            'x' => 50,
+            'y' => 50,
+            'value' => 'Account Number: 12345678'
+        ],
+    ],
+    'transactions' => [
+        ['date' => '2023-06-01', 'memo' => 'Deposit', 'amount' => '100.00'],
+        ['date' => '2023-06-02', 'memo' => 'Withdrawal', 'amount' => '-20.00'],
+    ]
+];
+$tmpJson = tempnam(sys_get_temp_dir(), 'pdf');
+file_put_contents($tmpJson, json_encode($data));
+$cmd = escapeshellcmd("python3 " . __DIR__ . "/generate_pdf.py " . escapeshellarg($template) . " " . escapeshellarg($tmpJson) . " " . escapeshellarg($output));
+`$cmd`;
+unlink($tmpJson);
+echo "Generated PDF saved to $output\n";
+?>

--- a/pdf_layout/generate_pdf.py
+++ b/pdf_layout/generate_pdf.py
@@ -1,0 +1,78 @@
+import json
+import sys
+from PyPDF2 import PdfReader, PdfWriter
+from reportlab.pdfgen import canvas
+from reportlab.lib.pagesizes import letter
+from reportlab.pdfbase import pdfmetrics
+from reportlab.pdfbase.ttfonts import TTFont
+from reportlab.lib.units import mm
+import io
+
+
+def draw_overlay(data, template_reader):
+    overlays = []
+    for page_index in range(len(template_reader.pages)):
+        packet = io.BytesIO()
+        page = template_reader.pages[page_index]
+        width = float(page.mediabox.width)
+        height = float(page.mediabox.height)
+        c = canvas.Canvas(packet, pagesize=(width, height))
+
+        # Example fields for demonstration; real config should come from data
+        fields = data.get("fields", [])
+        for f in fields:
+            if f.get("page", 0) == page_index:
+                font = f.get("font", "Helvetica")
+                size = f.get("size", 12)
+                font_path = f.get("font_path")
+                if font_path:
+                    pdfmetrics.registerFont(TTFont(font, font_path))
+                c.setFont(font, size)
+                x = f.get("x", 0) * mm
+                y = height - f.get("y", 0) * mm
+                c.drawString(x, y, f.get("value", ""))
+
+        # Example repeating transactions
+        transactions = data.get("transactions", [])
+        if transactions and page_index == 0:
+            tx_y_start = 100 * mm
+            tx_y_step = 5 * mm
+            for i, tx in enumerate(transactions):
+                y = tx_y_start - i * tx_y_step
+                c.drawString(20 * mm, height - y, tx.get("date", ""))
+                c.drawString(40 * mm, height - y, tx.get("memo", ""))
+                c.drawRightString(width - 20 * mm, height - y, str(tx.get("amount", "")))
+
+        c.showPage()
+        c.save()
+        packet.seek(0)
+        overlays.append(PdfReader(packet))
+    return overlays
+
+
+def merge(template_path, data, output_path):
+    template_reader = PdfReader(template_path)
+    writer = PdfWriter()
+    overlays = draw_overlay(data, template_reader)
+    for i, page in enumerate(template_reader.pages):
+        overlay_page = overlays[i].pages[0]
+        page.merge_page(overlay_page)
+        writer.add_page(page)
+    with open(output_path, 'wb') as f_out:
+        writer.write(f_out)
+
+
+def main():
+    if len(sys.argv) != 4:
+        print("Usage: generate_pdf.py TEMPLATE DATA_JSON OUTPUT")
+        return 1
+    template = sys.argv[1]
+    data_json = sys.argv[2]
+    output = sys.argv[3]
+    with open(data_json) as f:
+        data = json.load(f)
+    merge(template, data, output)
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- add `generate_pdf.py` showcasing PyPDF2 usage for overlaying text on PDFs
- add `generate_pdf.php` that calls the Python helper
- document usage in `pdf_layout/README.md`

## Testing
- `python3 pdf_layout/generate_pdf.py Banks_Templates/Chase/Chase_Personal_оригинал.pdf /tmp/data.json /tmp/out.pdf`


------
https://chatgpt.com/codex/tasks/task_e_683faf55b41083288295b7449ea5bfeb